### PR TITLE
feat(rules): Expand Default Ruleset with Comprehensive Metal Ions

### DIFF
--- a/resources/default.rules.toml
+++ b/resources/default.rules.toml
@@ -1,6 +1,6 @@
 # ==============================================================================
 #  Official DREIDING Atom Typing Ruleset for dreid-typer
-#  Version: 2.1.0
+#  Version: 2.2.0
 #  Authors: Tony Kan, William A. Goddard III
 # ==============================================================================
 
@@ -264,10 +264,22 @@ conditions = { element = "I" }
 # ------------------------------------------------------------------------------
 
 [[rule]]
-name = "Metal_Na"
+name = "Metal_Ag"
 priority = 20
-type = "Na"
-conditions = { element = "Na" }
+type = "Ag"
+conditions = { element = "Ag" }
+
+[[rule]]
+name = "Metal_Au"
+priority = 20
+type = "Au"
+conditions = { element = "Au" }
+
+[[rule]]
+name = "Metal_Ba"
+priority = 20
+type = "Ba"
+conditions = { element = "Ba" }
 
 [[rule]]
 name = "Metal_Ca"
@@ -276,16 +288,52 @@ type = "Ca"
 conditions = { element = "Ca" }
 
 [[rule]]
+name = "Metal_Cd"
+priority = 20
+type = "Cd"
+conditions = { element = "Cd" }
+
+[[rule]]
+name = "Metal_Co"
+priority = 20
+type = "Co"
+conditions = { element = "Co" }
+
+[[rule]]
+name = "Metal_Cs"
+priority = 20
+type = "Cs"
+conditions = { element = "Cs" }
+
+[[rule]]
+name = "Metal_Cu"
+priority = 20
+type = "Cu"
+conditions = { element = "Cu" }
+
+[[rule]]
 name = "Metal_Fe"
 priority = 20
 type = "Fe"
 conditions = { element = "Fe" }
 
 [[rule]]
-name = "Metal_Zn"
+name = "Metal_Hg"
 priority = 20
-type = "Zn"
-conditions = { element = "Zn" }
+type = "Hg"
+conditions = { element = "Hg" }
+
+[[rule]]
+name = "Metal_K"
+priority = 20
+type = "K"
+conditions = { element = "K" }
+
+[[rule]]
+name = "Metal_Li"
+priority = 20
+type = "Li"
+conditions = { element = "Li" }
 
 [[rule]]
 name = "Metal_Mg"
@@ -300,16 +348,34 @@ type = "Mn"
 conditions = { element = "Mn" }
 
 [[rule]]
-name = "Metal_Ti"
+name = "Metal_Na"
 priority = 20
-type = "Ti"
-conditions = { element = "Ti" }
+type = "Na"
+conditions = { element = "Na" }
 
 [[rule]]
-name = "Metal_Tc"
+name = "Metal_Ni"
 priority = 20
-type = "Tc"
-conditions = { element = "Tc" }
+type = "Ni"
+conditions = { element = "Ni" }
+
+[[rule]]
+name = "Metal_Pd"
+priority = 20
+type = "Pd"
+conditions = { element = "Pd" }
+
+[[rule]]
+name = "Metal_Pt"
+priority = 20
+type = "Pt"
+conditions = { element = "Pt" }
+
+[[rule]]
+name = "Metal_Rb"
+priority = 20
+type = "Rb"
+conditions = { element = "Rb" }
 
 [[rule]]
 name = "Metal_Ru"
@@ -318,7 +384,25 @@ type = "Ru"
 conditions = { element = "Ru" }
 
 [[rule]]
-name = "Metal_Hg"
+name = "Metal_Sr"
 priority = 20
-type = "Hg"
-conditions = { element = "Hg" }
+type = "Sr"
+conditions = { element = "Sr" }
+
+[[rule]]
+name = "Metal_Tc"
+priority = 20
+type = "Tc"
+conditions = { element = "Tc" }
+
+[[rule]]
+name = "Metal_Ti"
+priority = 20
+type = "Ti"
+conditions = { element = "Ti" }
+
+[[rule]]
+name = "Metal_Zn"
+priority = 20
+type = "Zn"
+conditions = { element = "Zn" }


### PR DESCRIPTION
### Summary:

Expands the default DREIDING ruleset (`default.rules.toml`) to include typing rules for a much broader range of metal ions. This ensures that systems containing common physiological ions (like K+, Cl-) and transition metals (like Ag, Au, Cu, Pt) can be typed out-of-the-box without requiring custom rule files. These new rules act as low-priority fallbacks for isolated or non-hybridized metal atoms.

### Changes:

- **Added Rules for Alkali Metals:**
  - Added typing rules for Lithium (`Li`), Potassium (`K`), Rubidium (`Rb`), and Cesium (`Cs`).

- **Added Rules for Alkaline Earth Metals:**
  - Added typing rules for Strontium (`Sr`) and Barium (`Ba`).

- **Added Rules for Transition Metals:**
  - Added typing rules for Silver (`Ag`), Gold (`Au`), Cadmium (`Cd`), Cobalt (`Co`), Copper (`Cu`), Nickel (`Ni`), Palladium (`Pd`), and Platinum (`Pt`).

- **Reorganized Metal Rules:**
  - Sorted all metal rules alphabetically by element symbol within the TOML file for better maintainability.