### PR TITLE
fix(builder): Generate All Three Inversion Terms per Planar Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At a high level the library walks through:
 
 - **Chemically faithful perception:** built-in algorithms cover SSSR ring search, strict Kekulé expansion, charge/lone pair templates for heteroatoms, aromaticity categorization (including anti-aromatic detection), resonance propagation, and hybridization inference.
 - **Deterministic typing engine:** TOML rules are sorted by priority and evaluated until a fixed point, making neighbor-dependent rules (e.g., `H_HB`) converge without guesswork.
-- **Engine-agnostic topology:** outputs canonicalized bonds, angles, proper and improper dihedrals ready for any simulator that consumes DREIDING-style terms.
+- **Engine-agnostic topology:** outputs canonicalized bonds, angles, torsions, and inversions ready for any simulator that consumes DREIDING-style terms.
 - **Extensible ruleset:** ship with curated defaults (`resources/default.rules.toml`) and load or merge custom rule files at runtime.
 - **Rust-first ergonomics:** zero `unsafe`, comprehensive unit/integration tests, and precise error variants for validation, perception, and typing failures.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ At a high level the library walks through:
 
 1. **Perception:** six ordered passes (rings → Kekulé expansion → electron bookkeeping → aromaticity → resonance → hybridization) that upgrade raw connectivity into a rich `AnnotatedMolecule`.
 2. **Typing:** an iterative, priority-sorted rule engine that resolves the final DREIDING atom label for every atom.
-3. **Building:** a pure graph traversal that emits canonical bonds, angles, and torsions as a `MolecularTopology`.
+3. **Building:** a pure graph traversal that emits canonical bonds, angles, torsions, and inversions as a `MolecularTopology`.
 
 ## Features
 

--- a/docs/01_pipeline.md
+++ b/docs/01_pipeline.md
@@ -46,13 +46,13 @@ Once a `MolecularGraph` enters the pipeline, it is immediately converted into an
 
 The `MolecularTopology` is the final product of the pipeline. It is a clean, structured representation tailored specifically for consumption by molecular simulation engines.
 
-- **Purpose:** To provide a complete list of all particles and interaction terms (bonds, angles, dihedrals) required to define a DREIDING force field model.
+- **Purpose:** To provide a complete list of all particles and interaction terms (bonds, angles, torsions, inversions) required to define a DREIDING force field model.
 - **Structure:**
   - A list of final `Atom`s, now including their assigned `atom_type`.
-  - Deduplicated lists of `Bond`s, `Angle`s, `ProperDihedral`s, and `ImproperDihedral`s.
+  - Deduplicated lists of `Bond`s, `Angle`s, `Torsion`s, and `Inversion`s.
 - **Design Rationale:**
   - **Simulation-Oriented:** The structure directly maps to the needs of a simulation setup. It discards intermediate perception data (like `lone_pairs` or `steric_number`) that is not directly part of the final force field definition.
-  - **Canonical Representation:** Each topological component (`Angle`, `Dihedral`) is stored in a canonical form (e.g., atom indices are sorted). This simplifies consumption by downstream tools, as it eliminates ambiguity and the need for further deduplication.
+  - **Canonical Representation:** Each topological component (`Angle`, `Torsion`, `Inversion`) is stored in a canonical form (e.g., atom indices are sorted). This simplifies consumption by downstream tools, as it eliminates ambiguity and the need for further deduplication.
 
 ## 2. The Data Flow: A Deterministic Transformation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,14 +46,14 @@ graph TD
     Annotated -- "Provides geometry + resonance context" --> BuilderPhase;
     AtomTypes -- "Provides atom type info" --> BuilderPhase;
 
-    BuilderPhase -- "Generates bonds, angles, dihedrals" --> OutputTopology;
+    BuilderPhase -- "Generates bonds, angles, torsions, inversions" --> OutputTopology;
 ```
 
 - **Phase 1: Perception (`perception::perceive`):** Takes the raw `MolecularGraph` and emits an `AnnotatedMolecule`. Six ordered passes (rings, kekulization, electrons, aromaticity, resonance, hybridization) enrich each atom with bonding, charge, lone-pair, ring, and delocalization metadata. The output is immutable and shared with later stages.
 
 - **Phase 2: Typing (`typing::engine::assign_types`):** Runs a deterministic fixed-point solver over the `AnnotatedMolecule`. It evaluates TOML rules parsed via `typing::rules::parse_rules`, honoring priorities and neighbor-dependent constraints until every atom is assigned a DREIDING type.
 
-- **Phase 3: Building (`builder::build_topology`):** Consumes the annotated atoms plus the final type vector to produce a canonical `MolecularTopology`. Helper routines enumerate bonds, angles, proper/ improper dihedrals, and collapse duplicates using canonical ordering so downstream engines receive stable identifiers.
+- **Phase 3: Building (`builder::build_topology`):** Consumes the annotated atoms plus the final type vector to produce a canonical `MolecularTopology`. Helper routines enumerate bonds, angles, torsions, and inversions, and collapse duplicates using canonical ordering so downstream engines receive stable identifiers.
 
 ## Directory of Architectural Documents
 

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -257,30 +257,35 @@ mod tests {
     }
 
     #[test]
-    fn build_propers_emits_all_valid_dihedrals() {
+    fn build_torsions_emits_all_valid_dihedrals() {
         let (molecule, _) = planar_fragment();
 
-        let propers = build_propers(&molecule);
+        let torsions = build_torsions(&molecule);
         let expected: HashSet<_> = vec![
-            ProperDihedral::new(0, 1, 2, 4),
-            ProperDihedral::new(3, 1, 2, 4),
-            ProperDihedral::new(1, 2, 4, 5),
+            Torsion::new(0, 1, 2, 4),
+            Torsion::new(3, 1, 2, 4),
+            Torsion::new(1, 2, 4, 5),
         ]
         .into_iter()
         .collect();
 
-        assert_eq!(propers, expected);
+        assert_eq!(torsions, expected);
     }
 
     #[test]
-    fn build_impropers_targets_planar_degree_three_centers() {
+    fn build_inversions_generates_three_per_planar_center() {
         let (molecule, _) = planar_fragment();
 
-        let impropers = build_impropers(&molecule);
-        let expected: HashSet<_> = vec![ImproperDihedral::new(0, 2, 1, 3)]
-            .into_iter()
-            .collect();
+        let inversions = build_inversions(&molecule);
+        let expected: HashSet<_> = vec![
+            Inversion::new(1, 0, 2, 3),
+            Inversion::new(1, 2, 0, 3),
+            Inversion::new(1, 3, 0, 2),
+        ]
+        .into_iter()
+        .collect();
 
-        assert_eq!(impropers, expected);
+        assert_eq!(inversions.len(), 3);
+        assert_eq!(inversions, expected);
     }
 }

--- a/src/core/topology.rs
+++ b/src/core/topology.rs
@@ -80,7 +80,7 @@ pub struct Torsion {
 }
 
 impl Torsion {
-    /// Creates a new torsion with terminals atoms sorted to a canonical order.
+    /// Creates a new torsion with terminal atoms sorted to a canonical order.
     pub fn new(i: usize, j: usize, k: usize, l: usize) -> Self {
         let fwd = (i, j, k, l);
         let rev = (l, k, j, i);

--- a/src/core/topology.rs
+++ b/src/core/topology.rs
@@ -131,18 +131,37 @@ mod tests {
     }
 
     #[test]
-    fn proper_dihedral_new_canonicalizes_orientation() {
-        let forward = ProperDihedral::new(1, 2, 3, 4);
-        let reversed = ProperDihedral::new(4, 3, 2, 1);
+    fn torsion_new_canonicalizes_orientation() {
+        let forward = Torsion::new(1, 2, 3, 4);
+        let reversed = Torsion::new(4, 3, 2, 1);
 
         assert_eq!(forward.atom_ids, reversed.atom_ids);
         assert_eq!(forward.atom_ids, (1, 2, 3, 4));
     }
 
     #[test]
-    fn improper_dihedral_new_sorts_plane_atoms() {
-        let improper = ImproperDihedral::new(9, 1, 5, 4);
-        assert_eq!(improper.atom_ids, (1, 4, 5, 9));
+    fn inversion_new_sorts_only_plane_atoms() {
+        let inv = Inversion::new(5, 9, 4, 1);
+        assert_eq!(inv.atom_ids, (5, 9, 1, 4));
+
+        let inv2 = Inversion::new(5, 1, 9, 4);
+        assert_eq!(inv2.atom_ids, (5, 1, 4, 9));
+        assert_ne!(inv.atom_ids, inv2.atom_ids);
+    }
+
+    #[test]
+    fn inversion_three_terms_per_center_are_distinct() {
+        let inv1 = Inversion::new(0, 1, 2, 3);
+        let inv2 = Inversion::new(0, 2, 1, 3);
+        let inv3 = Inversion::new(0, 3, 1, 2);
+
+        assert_eq!(inv1.atom_ids, (0, 1, 2, 3));
+        assert_eq!(inv2.atom_ids, (0, 2, 1, 3));
+        assert_eq!(inv3.atom_ids, (0, 3, 1, 2));
+
+        assert_ne!(inv1, inv2);
+        assert_ne!(inv2, inv3);
+        assert_ne!(inv1, inv3);
     }
 
     #[test]
@@ -152,7 +171,7 @@ mod tests {
         assert!(topology.atoms.is_empty());
         assert!(topology.bonds.is_empty());
         assert!(topology.angles.is_empty());
-        assert!(topology.propers.is_empty());
-        assert!(topology.impropers.is_empty());
+        assert!(topology.torsions.is_empty());
+        assert!(topology.inversions.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,7 @@ pub use crate::core::properties::{
     Element, GraphBondOrder, Hybridization, ParseBondOrderError, ParseElementError,
     ParseHybridizationError, TopologyBondOrder,
 };
-pub use crate::core::topology::{
-    Angle, Atom, Bond, ImproperDihedral, MolecularTopology, ProperDihedral,
-};
+pub use crate::core::topology::{Angle, Atom, Bond, Inversion, MolecularTopology, Torsion};
 
 /// Rule parsing and customization utilities.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! assert_eq!(topology.atoms.len(), 9);
 //! assert_eq!(topology.bonds.len(), 8);
 //! assert_eq!(topology.angles.len(), 13);
-//! assert_eq!(topology.propers.len(), 12);
+//! assert_eq!(topology.torsions.len(), 12);
 //!
 //! // Check the assigned DREIDING atom types.
 //! assert_eq!(topology.atoms[c1].atom_type, "C_3");    // sp3 Carbon


### PR DESCRIPTION
### Summary:

Corrected the topology builder to generate three distinct inversion terms for each planar center, adhering to the DREIDING force field specification. Previously, the builder collapsed these terms into a single `ImproperDihedral`, which under-constrained the planarity of sp2 centers. The new implementation explicitly generates an inversion for each neighbor acting as the unique axis, ensuring robust planarity enforcement. Additionally, the topology terminology has been updated to `Torsion` and `Inversion` to better reflect standard force field nomenclature.

### Changes:

- **Renamed Topology Terms:**
  - Renamed `ProperDihedral` to `Torsion` and `ImproperDihedral` to `Inversion` in `core::topology` and throughout the codebase.
  - Updated documentation to reflect these standard terms.

- **Corrected Inversion Generation Logic:**
  - Refactored `build_inversions` (formerly `build_improper_dihedrals`) to iterate through all three neighbors of a planar center.
  - For a center `I` with neighbors `J, K, L`, the builder now emits three distinct terms: `I-J-KL`, `I-K-JL`, and `I-L-JK`.
  - Updated the `Inversion` constructor to sort only the two plane atoms, preserving the unique axis atom to distinguish the three terms.

- **Updated Tests:**
  - Modified unit tests in `builder/mod.rs` to verify that three inversion terms are generated for a planar center instead of one.
  - Updated integration tests to expect `torsions` instead of `proper_dihedrals` and `inversions` instead of `improper_dihedrals`.